### PR TITLE
chanage cron job for enable startpup

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ To start the `BTC` agent and configure it with two pool server addresses:
 ```bash
 sudo ./start.sh btc btc.viabtc.com:3333:nossl btc-ssl.viabtc.io:551:ssl
 ```
-**Running Test: **
+**Running Test:**
 ```bash
 telnet 127.0.0.1 3333
 ```

--- a/README.md
+++ b/README.md
@@ -1,7 +1,4 @@
 # MinerAgent Deployment Guide for Linux (Ubuntu) With Startup feature
-
-English | [简体中文](./README.md) | [Русский](./README.ru.md)
-
 ## System Requirements
 - Operating System: Ubuntu Server 22.04 x86_64 or higher
 - Processor: 4 cores or more

--- a/README.md
+++ b/README.md
@@ -1,26 +1,87 @@
-# MinerAgent 使用指南
+# MinerAgent Deployment Guide for Linux (Ubuntu) With Startup feature
 
-## 有必要搭建代理服务器吗？
+English | [简体中文](./README.md) | [Русский](./README.ru.md)
 
-大型矿场由于矿机数量巨大，如果直接连接矿池地址配置进行挖矿，可能会因为网络等原因导致拒绝率较高。特别是在矿池任务切换期间，如果矿场的网络不够稳定，可能会出现矿池已切换任务但矿机依然在执行上一个任务的情况，造成算力浪费。
+## System Requirements
+- Operating System: Ubuntu Server 22.04 x86_64 or higher
+- Processor: 4 cores or more
+- Memory: 8 GB RAM or more
+- Storage: 60 GB or more
 
-如果在矿场中安装一个代理服务器，矿池下发任务时先下发到代理服务器，然后由代理服务器下发到矿机，提交结果时，矿机先提交到代理服务器，然后由代理服务器提交给矿池挖矿服务器，这样可以大大提高挖矿的稳定性和降低拒绝率。
+## Deployment Steps
+All steps below should be performed in the `Terminal` .
 
-如果您运营着大算力矿场，管理着大量矿机，那么可以考虑搭建自己的挖矿代理服务器。
+### 1. Configuration Environment 
+Before deploying MinerAgent, you need to install the required dependencies by running the following commands:
+```bash
+sudo apt update
+sudo apt install git
+sudo apt install jq
+```
 
-## 搭建代理服务器的好处
+### 2. Download MinerAgent
+If you want to install MinerAgent in a specific directory, use the `cd` command to navigate your desired location. This guide uses the default directory (`cd ~`) as the installation location.  
+Run the following command to download MinerAgent:
+```bash
+git clone https://github.com/viabtc/mineragent.git
+```
+After downloading, navigate to the following directory:  
+```bash
+cd mineragent/linux
+```
+### 3. Initial Startup of MinerAgent
+For first-time deployment, you can use the `start.sh` script in the current directory to start the MinerAgent service in one step, and automatically set up cron to periodically monitor whether the agent service is running properly.  
+**Basic Usage:**  
+To start the agent for a specific coin (e.g., `BTC` or `LTC`):  
+```bash
+sudo ./start.sh btc
+or
+sudo ./start.sh ltc
+```
+**Advanced Usage (configurable mining pool server)**  
+You can configure up to three mining pool server addresses.  
+The format of mining pool server address: `host:port:[ssl|nossl]`  
+- `host`: Mining pool server address (e.g., `btc.viabtc.com`)
+- `port`: Mining pool server port (e.g., `3333`)
+- `[ssl|nossl]`: Whether the mining pool server is SSL-encrypted
 
-1. 代理服务器专门负责提交和下发任务，矿机安心挖矿
-2. 减少带宽占用，矿池和矿场的网络资源都得到释放
-3. 提高挖矿稳定性，降低网络不稳定导致的算力浪费
+**Example:**  
+To start the `BTC` agent and configure it with two pool server addresses:
+```bash
+sudo ./start.sh btc btc.viabtc.com:3333:nossl btc-ssl.viabtc.io:551:ssl
+```
+**Running Test: **
+```bash
+telnet 127.0.0.1 3333
+```
+if you can see :
+```
+Trying 127.0.0.1...
+Connected to 127.0.0.1.
+```
+MinerAgent is waiting for miners
+### 4. Connecting Miners
+Miners should connect to the agent service using `IP:Port`.
+IP is the `server IP` where the agent is running. The default ports for the BTC agent are `[3333 / 443 / 25]`. The default ports for the LTC agent are `[5555 / 446 / 26]`. You only need to use one of the listed ports.
+How to check `server IP`:  
+Run:
+```bash
+ip -a
+```
+You will see output similar to:
+```bash
+1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN group default qlen 1000
+    link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00
+    inet 127.0.0.1/8 scope host lo
+       valid_lft forever preferred_lft forever
+2: eth0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc fq_codel state UP group default qlen 1000
+    link/ether 08:00:27:0e:63:9b brd ff:ff:ff:ff:ff:ff
+    inet 192.168.1.100/24 brd 192.168.1.255 scope global dynamic noprefixroute eth0
+       valid_lft 86311sec preferred_lft 86311sec
+```
+You should look for your network interface, which is usually `eth0` (wired connection) or `wlan0` (wireless connection).  
+Within the details of these interfaces, find the line that begins with `inet`.  
+`inet 192.168.1.100/24`  
+Here, `192.168.1.100` is your `server IP` address.  
+In the miner’s configuration page, set the BTC mining URL as: `stratum+tcp://192.168.1.100:3333`.
 
-需要注意：代理服务器目前仅支持BTC和LTC两个币种。
-
-## 准备工作
-
-开始搭建挖矿代理服务器前，您需要做好以下准备：
-
-1. 一台部署代理服务器的电脑（Windows或者ubuntu系统），并且可以联网
-2. 电脑和矿机需要在一个局域网内
-
-需要注意：配置好代理之后，您这台电脑将充当挖矿代理服务器，需要长时间运行。

--- a/linux/README.en.md
+++ b/linux/README.en.md
@@ -50,6 +50,15 @@ To start the `BTC` agent and configure it with two pool server addresses:
 ```bash
 sudo ./start.sh btc btc.viabtc.com:3333:nossl btc-ssl.viabtc.io:551:ssl
 ```
+**Running Test: **
+```bash
+telnet 127.0.0.1 3333
+```
+if you can see :
+```
+Trying 127.0.0.1...
+Connected to 127.0.0.1.
+```
 ### 4. Connecting Miners
 Miners should connect to the agent service using `IP:Port`.
 IP is the `server IP` where the agent is running. The default ports for the BTC agent are `[3333 / 443 / 25]`. The default ports for the LTC agent are `[5555 / 446 / 26]`. You only need to use one of the listed ports.

--- a/linux/README.en.md
+++ b/linux/README.en.md
@@ -50,7 +50,7 @@ To start the `BTC` agent and configure it with two pool server addresses:
 ```bash
 sudo ./start.sh btc btc.viabtc.com:3333:nossl btc-ssl.viabtc.io:551:ssl
 ```
-**Running Test: **
+**Running Test:** 
 ```bash
 telnet 127.0.0.1 3333
 ```

--- a/linux/start.sh
+++ b/linux/start.sh
@@ -125,10 +125,13 @@ cd "$SCRIPT_DIR" || exit
 # Setup cron job for the specified miner
 CHECK_ALIVE_SCRIPT="$AGENT_DIR/shell/check_alive.sh"
 if [ -f "$CHECK_ALIVE_SCRIPT" ]; then
-    CRON_JOB="*/1 * * * * $CHECK_ALIVE_SCRIPT >/dev/null 2>&1"
-    # Add the cron job if it doesn't exist
-    (crontab -l 2>/dev/null | grep -Fq "$CHECK_ALIVE_SCRIPT") || (crontab -l 2>/dev/null; echo "$CRON_JOB") | crontab -
-    echo -e "${GREEN}Cron job for ${MINER}_mineragent has been set up.${NC}"
+
+CRON_JOB="*/1 * * * * $CHECK_ALIVE_SCRIPT >/dev/null 2>&1"
+    # Add the cron job if it doesn't exist (for root user)
+    (sudo crontab -l -u root 2>/dev/null | grep -Fq "$CHECK_ALIVE_SCRIPT") || \
+    (sudo crontab -l -u root 2>/dev/null; echo "$CRON_JOB") | sudo crontab -u root -
+    echo -e "${GREEN}Cron job for ${MINER}_mineragent has been set up (root).${NC}"
+
 else
     echo -e "${RED}Warning: check_alive.sh not found for $MINER. Cron job not set.${NC}"
 fi


### PR DESCRIPTION
In  ```/linux/start.sh```, a cron job will be added for the user logged into the server. after any power loss or server shutdown, if the user is not in the administrator group then ```check-alive.sh``` is not running, the client should start it manually .
Therefore, I changed the cron job section to add this cron job under the root user 

I also wrote a method for testing on ports 3333 to check if they are listening, which is documented
**testing listening for BTC asic**
```telent 127.0.0.1:3333``` 